### PR TITLE
switching ex_doc dependency to dev/test only envs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule TurbolinksPlug.Mixfile do
   defp deps do
     [
       {:plug, "~> 1.5"},
-      {:ex_doc, "~> 0.18"}
+      {:ex_doc, "~> 0.18", only: [:dev, :test]}
     ]
   end
 


### PR DESCRIPTION
Within out project we're getting this error when trying to perform `mix deps.get`: 
```
```
Dependencies have diverged:
* ex_doc (Hex package)
  the :only option for dependency ex_doc

  > In mix.exs:
    {:ex_doc, ">= 0.0.0", [env: :prod, repo: "hexpm", hex: "ex_doc", only: [:dev, :test], manager: :mix]}

  does not match the :only option calculated for

  > In deps/turbolinks_plug/mix.exs:
    {:ex_doc, "~> 0.18", [env: :prod, hex: "ex_doc", repo: "hexpm", optional: false]}

  Remove the :only restriction from your dep
** (Mix) Can't continue due to errors on dependencies
```

Current PR only changes environments for which `ex_doc` mandatory. 